### PR TITLE
Re-arrange useEffect to reduce race condition

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,12 +37,13 @@ const ref = useRef<HTMLDivElement | null>(null);
 
 useEffect(() => {
   (async () => {
-    const target = ref.current;
-    if (!target) return;
-    while (target.firstChild) target.removeChild(target.firstChild);
     const mod = await import(/* webpackIgnore: true */ module);
     const component = mod[importName];
     const element = component instanceof Function ? await component() : component;
+
+    const target = ref.current;
+    if (!target) return;
+    while (target.firstChild) target.removeChild(target.firstChild);
     target.append(element);
   })();
 }, [importName, module]);

--- a/src/components/observableEmbed/client.tsx
+++ b/src/components/observableEmbed/client.tsx
@@ -14,12 +14,13 @@ export const ObservableEmbedClient: React.FC<ObservableEmbedProps> = ({
 
   useEffect(() => {
     (async () => {
-      const target = ref.current;
-      if (!target) return;
-      while (target.firstChild) target.removeChild(target.firstChild);
       const mod = await import(/* webpackIgnore: true */ module);
       const component = mod[importName];
       const element = component instanceof Function ? await component() : component;
+
+      const target = ref.current;
+      if (!target) return;
+      while (target.firstChild) target.removeChild(target.firstChild);
       target.append(element);
     })();
   }, [importName, module]);


### PR DESCRIPTION
I think this should prevent getting double renders, especially is local development. It fixes the race condition where the component is rendered twice in quick succession. Before this PR, there was an `await` point between when the contents of the target were removed and when the new content was added. This gave an oppourtunity for the second render of the component to add it's content.

By moving the await point to before the element removal, it should eliminate the race condition.
